### PR TITLE
部分キャッシュリストア導入

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,12 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          cache: maven
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Build with Maven
         run: mvn clean package


### PR DESCRIPTION
setup-javaのcacheはkeyが完全一致でなくてはならないため使いづらい
そのため部分キャッシュリストアを導入する
