### PR TITLE
H2 Databaseの設定追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ replay_pid*
 
 # IntelliJ IDEA
 .idea/
+
+# H2
+.data/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,32 @@
 ```bash
 ./mvnw spring-boot:run
 ```
+or
+```bash
+java -jar ./target/*.jar
+```
+
+## 画面表示
+- http://localhost:8080 にアクセスする
+
+## DB
+- Embedded H2 Database を使用している
+- H2コンソール表示
+  - http://localhost:8080/h2-console
+### 前提
+- ファイル(h2.mv.db)が用意されていること
+  - 無い場合は下記コマンドで作成すること
+```bash
+$ mkdir .data
+$ touch ./.data/h2.mv.db
+```
+- H2コンソールを利用する場合は`/src/main/resources/application.properties`に`spring.h2.console.enabled=true`を書き加えるか、下記コマンドを実行すること
+```
+./mvnw spring-boot:run -Dspring-boot.run.arguments=--spring.h2.console.enabled=true
+```
+```
+java -jar ./target/*.jar --spring.h2.console.enabled=true
+```
 
 ## 依存関係
 - ツリー表示

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ or
 ```bash
 java -jar ./target/*.jar
 ```
+### devプロファイル指定
+- `spring.profiles.active=dev`を指定することで`application-dev.properties`の値が使用される
+```
+./mvnw spring-boot:run -Dspring-boot.run.arguments=--spring.profiles.active=dev
+```
 
 ## 画面表示
 - http://localhost:8080 にアクセスする

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>com.example</groupId>
 	<artifactId>divichart</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.0.2-SNAPSHOT</version>
 	<name>divichart</name>
 	<properties>
 		<java.version>11</java.version>

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,4 +1,6 @@
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.url=jdbc:h2:./.data/h2;MODE=MySQL
+spring.datasource.username=super
+spring.datasource.password=
 spring.datasource.sql-script-encoding=UTF-8
-spring.h2.console.enabled=false
+spring.h2.console.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,4 @@ spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.url=jdbc:h2:./.data/h2;MODE=MySQL
 spring.datasource.username=super
 spring.datasource.password=
+spring.datasource.sql-script-encoding=UTF-8

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:./.data/h2;MODE=MySQL
+spring.datasource.username=super
+spring.datasource.password=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,4 @@ spring.datasource.url=jdbc:h2:./.data/h2;MODE=MySQL
 spring.datasource.username=super
 spring.datasource.password=
 spring.datasource.sql-script-encoding=UTF-8
+spring.h2.console.enabled=false


### PR DESCRIPTION
- H2コンソールからDB操作が行えるように整備した
- 厳密には`spring.h2.console.enabled=true`の設定だけ加えれば良さそう
  - 他の設定は現状では必要ない認識
- 後続ＰＲで区切りの良いところまで作業をおこないたいためSNAPSHOTのままにしている
  - 今後の予定
    - 起動時のテーブル作成＆データ投入の仕組み作成
    - ＤＢから値を取得して画面表示できるところまで実装
  - 上記2点が終わったらSNAPSHOTを外そうと考えている