### PR TITLE
ログイン処理でDBを参照するように変更

### DIFF
--- a/src/main/java/com/example/divichart/configuration/WebSecurityConfig.java
+++ b/src/main/java/com/example/divichart/configuration/WebSecurityConfig.java
@@ -7,10 +7,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.provisioning.JdbcUserDetailsManager;
 import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
@@ -53,27 +49,10 @@ public class WebSecurityConfig {
         return http.build();
     }
 
-//    @Bean
-//    public UserDetailsService userDetailsService() {
-//        UserDetails user = User.builder()
-//                .username("admin")
-//                .password("{bcrypt}$2a$10$kxhJnySfXtAL6xjlVks36e.NkqIiXCSUHy2Z2zT8HO8jETJ/t6YwK")
-//                .roles("USER")
-//                .build();
-//
-//        return new InMemoryUserDetailsManager(user);
-//    }
-
-//    @Bean
-//    public PasswordEncoder passwordEncoder() {
-//        return new BCryptPasswordEncoder();
-//    }
-
     @Bean
     public UserDetailsManager userDetailsManager() {
         JdbcUserDetailsManager users = new JdbcUserDetailsManager(this.dataSource);
         // ユーザーを追加したい時
-        // user.createUser(makeUser("user", "pass", "USER"));
         UserDetails user = User.builder()
                 .username("admin")
                 .password("{bcrypt}$2a$10$kxhJnySfXtAL6xjlVks36e.NkqIiXCSUHy2Z2zT8HO8jETJ/t6YwK")

--- a/src/main/java/com/example/divichart/configuration/WebSecurityConfig.java
+++ b/src/main/java/com/example/divichart/configuration/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.divichart.configuration;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -7,12 +8,21 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.provisioning.JdbcUserDetailsManager;
+import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+
+import javax.sql.DataSource;
 
 @Configuration
 @EnableWebSecurity
 public class WebSecurityConfig {
+
+    @Autowired
+    private DataSource dataSource;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -43,14 +53,34 @@ public class WebSecurityConfig {
         return http.build();
     }
 
+//    @Bean
+//    public UserDetailsService userDetailsService() {
+//        UserDetails user = User.builder()
+//                .username("admin")
+//                .password("{bcrypt}$2a$10$kxhJnySfXtAL6xjlVks36e.NkqIiXCSUHy2Z2zT8HO8jETJ/t6YwK")
+//                .roles("USER")
+//                .build();
+//
+//        return new InMemoryUserDetailsManager(user);
+//    }
+
+//    @Bean
+//    public PasswordEncoder passwordEncoder() {
+//        return new BCryptPasswordEncoder();
+//    }
+
     @Bean
-    public UserDetailsService userDetailsService() {
+    public UserDetailsManager userDetailsManager() {
+        JdbcUserDetailsManager users = new JdbcUserDetailsManager(this.dataSource);
+        // ユーザーを追加したい時
+        // user.createUser(makeUser("user", "pass", "USER"));
         UserDetails user = User.builder()
                 .username("admin")
                 .password("{bcrypt}$2a$10$kxhJnySfXtAL6xjlVks36e.NkqIiXCSUHy2Z2zT8HO8jETJ/t6YwK")
                 .roles("USER")
                 .build();
+        users.createUser(user);
 
-        return new InMemoryUserDetailsManager(user);
+        return users;
     }
 }

--- a/src/main/java/com/example/divichart/configuration/WebSecurityConfig.java
+++ b/src/main/java/com/example/divichart/configuration/WebSecurityConfig.java
@@ -53,12 +53,12 @@ public class WebSecurityConfig {
     public UserDetailsManager userDetailsManager() {
         JdbcUserDetailsManager users = new JdbcUserDetailsManager(this.dataSource);
         // ユーザーを追加したい時
-        UserDetails user = User.builder()
-                .username("admin")
-                .password("{bcrypt}$2a$10$kxhJnySfXtAL6xjlVks36e.NkqIiXCSUHy2Z2zT8HO8jETJ/t6YwK")
-                .roles("USER")
-                .build();
-        users.createUser(user);
+//        UserDetails user = User.builder()
+//                .username("admin")
+//                .password("{bcrypt}$2a$10$kxhJnySfXtAL6xjlVks36e.NkqIiXCSUHy2Z2zT8HO8jETJ/t6YwK")
+//                .roles("USER")
+//                .build();
+//        users.createUser(user);
 
         return users;
     }

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -4,3 +4,15 @@ CREATE TABLE IF NOT EXISTS `account` (
     `password` varchar(255) not null,
     PRIMARY KEY (`id`)
 );
+create table IF NOT EXISTS users(
+	username varchar_ignorecase(50) not null primary key,
+	password varchar_ignorecase(500) not null,
+	enabled boolean not null
+);
+
+create table IF NOT EXISTS authorities (
+	username varchar_ignorecase(50) not null,
+	authority varchar_ignorecase(50) not null,
+	constraint fk_authorities_users foreign key(username) references users(username)
+);
+create unique index IF NOT EXISTS ix_auth_username on authorities (username,authority);


### PR DESCRIPTION
- spring-securityでログインに使用するテーブルの定義は用意されているもよう
  - ref：https://spring.pleiades.io/spring-security/reference/servlet/authentication/passwords/jdbc.html
- そのテーブルを作成及び参照してログインするように変更した
- インメモリの記述は不要になるため削除した
- 今回やっていないこと
  - ログインユーザーの追加処理実装
    - 次回以降におこなうこととする
    - 作成する際はWebSecurityConfigに追加したコメント部が参考になると思われる
  - SQLの精査
    - 公式サイトの物をそのまま持ってきている
    - 必要であれば書き方などを見直したい