### PR TITLE
配当履歴CSV一括登録機能を追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-csv</artifactId>
+			<version>1.5</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>com.example</groupId>
 	<artifactId>divichart</artifactId>
-	<version>0.3.0</version>
+	<version>0.4.0</version>
 	<name>divichart</name>
 	<properties>
 		<java.version>11</java.version>

--- a/src/main/java/com/example/divichart/controller/ListController.java
+++ b/src/main/java/com/example/divichart/controller/ListController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
 import java.sql.Date;
@@ -38,6 +39,13 @@ public class ListController {
                          @ModelAttribute("receiptDate") Date receiptDate) {
         log.debug("配当履歴登録");
         service.insertDividendHistory(amountReceived, receiptDate);
+        return "redirect:/list";
+    }
+
+    @PostMapping("/csvInsert")
+    public String insert(@ModelAttribute("csvFile") MultipartFile csvFile) {
+        log.debug("配当履歴CSV一括登録");
+        service.csvInsert(csvFile);
         return "redirect:/list";
     }
 }

--- a/src/main/java/com/example/divichart/controller/ListController.java
+++ b/src/main/java/com/example/divichart/controller/ListController.java
@@ -34,13 +34,10 @@ public class ListController {
     }
 
     @PostMapping("/insert")
-    public String insert(Model model,
-                         @ModelAttribute("amountReceived") BigDecimal amountReceived,
+    public String insert(@ModelAttribute("amountReceived") BigDecimal amountReceived,
                          @ModelAttribute("receiptDate") Date receiptDate) {
         log.debug("配当履歴登録");
         service.insertDividendHistory(amountReceived, receiptDate);
-        List<DividendHistory> dividendHistoryList = service.getAllDividendHistory();
-        model.addAttribute("dividendHistoryList", dividendHistoryList);
-        return "list";
+        return "redirect:/list";
     }
 }

--- a/src/main/java/com/example/divichart/controller/ListController.java
+++ b/src/main/java/com/example/divichart/controller/ListController.java
@@ -27,7 +27,7 @@ public class ListController {
 
     @GetMapping
     public String index(Model model) {
-        log.info("配当履歴一覧画面表示");
+        log.debug("配当履歴一覧画面表示");
         List<DividendHistory> dividendHistoryList = service.getAllDividendHistory();
         model.addAttribute("dividendHistoryList", dividendHistoryList);
         return "list";
@@ -37,7 +37,7 @@ public class ListController {
     public String insert(Model model,
                          @ModelAttribute("amountReceived") BigDecimal amountReceived,
                          @ModelAttribute("receiptDate") Date receiptDate) {
-        // log.info("配当insert");
+        log.debug("配当履歴登録");
         service.insertDividendHistory(amountReceived, receiptDate);
         List<DividendHistory> dividendHistoryList = service.getAllDividendHistory();
         model.addAttribute("dividendHistoryList", dividendHistoryList);

--- a/src/main/java/com/example/divichart/service/ListService.java
+++ b/src/main/java/com/example/divichart/service/ListService.java
@@ -1,16 +1,27 @@
 package com.example.divichart.service;
 
+import com.example.divichart.controller.ListController;
 import com.example.divichart.entity.DividendHistory;
 import com.example.divichart.repository.DividendHistoryRepository;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.*;
 import java.math.BigDecimal;
 import java.sql.Date;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
 public class ListService {
+
+    private static final Logger log = LoggerFactory.getLogger(ListService.class);
 
     @Autowired
     DividendHistoryRepository repository;
@@ -24,6 +35,41 @@ public class ListService {
         DividendHistory dividendHistory =
                 new DividendHistory(amountReceived, receiptDate);
         repository.save(dividendHistory);
+    }
+
+    /**
+     * CSVファイルを読み取って配当履歴をinsertする
+     * @param csvFile CSVファイル内容
+     */
+    public void csvInsert(MultipartFile csvFile) {
+        List<DividendHistory> dividendHistoryList = new ArrayList<>(); //格納用のリスト
+        try {
+            InputStream stream = csvFile.getInputStream();
+            Reader reader = new InputStreamReader(stream, "SJIS"); //参考ページ：https://dev.classmethod.jp/articles/csv_read_java_char_trans/
+            BufferedReader buf = new BufferedReader(reader);
+
+            // CSVファイルをパース
+            CSVParser parse = CSVFormat.EXCEL.withHeader().parse(buf);
+            // レコードのリストに変換
+            List<CSVRecord> recordList = parse.getRecords();
+            // 各レコードを標準出力に出力＆画面表示用のリストに格納
+            for (CSVRecord record : recordList) { //参考ページ：http://itref.fc2web.com/java/commons/csv.html
+                if( !record.get("銘柄コード").isEmpty() ){
+                    BigDecimal amountReceived = new BigDecimal(record.get("受取金額[円/現地通貨]"));
+                    String rowDate = record.get("入金日");
+                    String sqlDate = rowDate.replace("/", "-");
+                    Date receiptDate = Date.valueOf(sqlDate);
+                    DividendHistory dividendHistory = new DividendHistory(
+                            amountReceived,
+                            receiptDate
+                    );
+                    dividendHistoryList.add(dividendHistory); // リストに加える
+                }
+            }
+            repository.saveAll(dividendHistoryList);
+        } catch (IOException e) { // csv読み込み失敗時
+            log.error(e.getMessage());
+        }
     }
 
 }

--- a/src/main/java/com/example/divichart/service/ListService.java
+++ b/src/main/java/com/example/divichart/service/ListService.java
@@ -43,8 +43,8 @@ public class ListService {
      */
     public void csvInsert(MultipartFile csvFile) {
         List<DividendHistory> dividendHistoryList = new ArrayList<>(); //格納用のリスト
-        try {
-            InputStream stream = csvFile.getInputStream();
+        try ( InputStream stream = csvFile.getInputStream() ){
+
             Reader reader = new InputStreamReader(stream, "SJIS"); //参考ページ：https://dev.classmethod.jp/articles/csv_read_java_char_trans/
             BufferedReader buf = new BufferedReader(reader);
 

--- a/src/main/resources/templates/list.html
+++ b/src/main/resources/templates/list.html
@@ -14,12 +14,10 @@
     </form>
     <br>
     <form th:action="@{/list/csvInsert}" method="post" enctype="multipart/form-data">
-        <div>
-            楽天証券の配当金・分配金一覧csvファイルを選択してください
-            <input type="file" name="csvFile" accept=".csv">
-            <p>例）dividendlist_20210111.csv</p>
-        </div>
-        <button type="submit">アップロード</button>
+        <div>楽天証券の配当金・分配金一覧CSVファイルを選択してください。</div>
+        <div>一括登録をします。<input type="file" name="csvFile" accept=".csv"></div>
+        <div>例）dividendlist_20210111.csv</div>
+        <div><input type="submit" value="アップロード"/></div>
     </form>
     <br>
     <table  border="1" cellspacing = "0">

--- a/src/main/resources/templates/list.html
+++ b/src/main/resources/templates/list.html
@@ -13,6 +13,15 @@
         <div><input type="submit" value="Insert"/></div>
     </form>
     <br>
+    <form th:action="@{/list/csvInsert}" method="post" enctype="multipart/form-data">
+        <div>
+            楽天証券の配当金・分配金一覧csvファイルを選択してください
+            <input type="file" name="csvFile" accept=".csv">
+            <p>例）dividendlist_20210111.csv</p>
+        </div>
+        <button type="submit">アップロード</button>
+    </form>
+    <br>
     <table  border="1" cellspacing = "0">
         <tr>
             <th>ID</th>


### PR DESCRIPTION
# 概要
- CSVファイルの内容を読み取って配当履歴を一括登録できるようにする

# 改修内容
- 楽天証券の配当CSVをアップロードして、配当履歴を一括登録できるようにした
  - CSVファイルを読み込むためのライブラリを追加している
  - CSVのヘッダーを使って必要な情報を取得している
- CSVファイルは配当履歴一覧画面からアップロードできるようにした
  - 確認画面は用意していないため、アップロードすると即insertされる仕様になっている

## その他ついでに改修したもの
- ListControllerで一覧を取得する処理が冗長だと感じたため構造を見直した
- ListControllerのログは不要なため消そうと思ったがdebugレベルで残すことにした

# 本PRで対応しないこと
- ページネーション追加
  - 一括登録により、一覧画面に大量のデータが表示されるようになってしまっている
  - 本来ならばページネーションを導入すべきだが今回はPRを分けて対応したい

# 備考
- 現状では必要最小限の情報のみ使用しているが、後ほど拡張して他の項目のデータも活用していく想定である
- 綺麗なコードは書いていないため、変数名や処理内容の見直しは後ほどした方が良い
