### PR TITLE
累計配当金額を線グラフで表示できるようにする

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>com.example</groupId>
 	<artifactId>divichart</artifactId>
-	<version>0.4.0</version>
+	<version>0.5.0</version>
 	<name>divichart</name>
 	<properties>
 		<java.version>11</java.version>

--- a/src/main/java/com/example/divichart/controller/LineChartController.java
+++ b/src/main/java/com/example/divichart/controller/LineChartController.java
@@ -1,8 +1,11 @@
 package com.example.divichart.controller;
 
+import com.example.divichart.service.LineChartService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -13,10 +16,14 @@ public class LineChartController {
 
     private static final Logger log = LoggerFactory.getLogger(LineChartController.class);
 
-    @GetMapping
-    public String index() {
-        log.debug("累計配当グラフ表示");
+    @Autowired
+    LineChartService service;
 
+    @GetMapping
+    public String index(Model model) {
+        log.debug("累計配当グラフ表示");
+        String chartData = service.getChartData("2020"); // TODO:年は変数にする
+        model.addAttribute("chartData", chartData);
         return "lineChart";
     }
 

--- a/src/main/java/com/example/divichart/controller/LineChartController.java
+++ b/src/main/java/com/example/divichart/controller/LineChartController.java
@@ -1,0 +1,23 @@
+package com.example.divichart.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+
+@Controller
+@RequestMapping( "/lineChart" )
+public class LineChartController {
+
+    private static final Logger log = LoggerFactory.getLogger(LineChartController.class);
+
+    @GetMapping
+    public String index() {
+        log.debug("累計配当グラフ表示");
+
+        return "lineChart";
+    }
+
+}

--- a/src/main/java/com/example/divichart/repository/DividendHistoryRepository.java
+++ b/src/main/java/com/example/divichart/repository/DividendHistoryRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.math.BigDecimal;
-import java.sql.Date;
+import java.time.LocalDate;
 
 public interface DividendHistoryRepository extends JpaRepository<DividendHistory, Long> {
     @Query(value = "SELECT COALESCE(SUM(amount_received), 0) FROM dividend_history", nativeQuery = true)
@@ -15,7 +15,7 @@ public interface DividendHistoryRepository extends JpaRepository<DividendHistory
     @Query(value = "SELECT COALESCE(SUM(amount_received), 0) FROM dividend_history " +
             "WHERE receipt_date BETWEEN :startDate AND :endDate", nativeQuery = true)
     BigDecimal getDividendSum(
-            @Param("startDate") Date startDate
-            ,@Param("endDate") Date endDate
+            @Param("startDate") LocalDate startDate
+            ,@Param("endDate") LocalDate endDate
     );
 }

--- a/src/main/java/com/example/divichart/repository/DividendHistoryRepository.java
+++ b/src/main/java/com/example/divichart/repository/DividendHistoryRepository.java
@@ -9,10 +9,10 @@ import java.math.BigDecimal;
 import java.sql.Date;
 
 public interface DividendHistoryRepository extends JpaRepository<DividendHistory, Long> {
-    @Query(value = "SELECT SUM(amount_received) FROM dividend_history", nativeQuery = true)
+    @Query(value = "SELECT COALESCE(SUM(amount_received), 0) FROM dividend_history", nativeQuery = true)
     BigDecimal getDividendSum();
 
-    @Query(value = "SELECT SUM(amount_received) FROM dividend_history " +
+    @Query(value = "SELECT COALESCE(SUM(amount_received), 0) FROM dividend_history " +
             "WHERE receipt_date BETWEEN :startDate AND :endDate", nativeQuery = true)
     BigDecimal getDividendSum(
             @Param("startDate") Date startDate

--- a/src/main/java/com/example/divichart/repository/DividendHistoryRepository.java
+++ b/src/main/java/com/example/divichart/repository/DividendHistoryRepository.java
@@ -2,7 +2,20 @@ package com.example.divichart.repository;
 
 import com.example.divichart.entity.DividendHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.math.BigDecimal;
+import java.sql.Date;
 
 public interface DividendHistoryRepository extends JpaRepository<DividendHistory, Long> {
-    // 後で書く
+    @Query(value = "SELECT SUM(amount_received) FROM dividend_history", nativeQuery = true)
+    BigDecimal getDividendSum();
+
+    @Query(value = "SELECT SUM(amount_received) FROM dividend_history " +
+            "WHERE receipt_date BETWEEN :startDate AND :endDate", nativeQuery = true)
+    BigDecimal getDividendSum(
+            @Param("startDate") Date startDate
+            ,@Param("endDate") Date endDate
+    );
 }

--- a/src/main/java/com/example/divichart/service/LineChartService.java
+++ b/src/main/java/com/example/divichart/service/LineChartService.java
@@ -14,18 +14,15 @@ public class LineChartService {
     @Autowired
     DividendHistoryRepository repository;
 
-    /*
-     * @return result グラフ描画用データ
+    /**
+     * グラフ描画用に、指定年の1月～12月までの配当累計を計算する
+     * @param year データ作成対象年
+     * @return グラフ描画用文字列
      */
     public String getChartData(String year) {
-
-        String chartData = "";
-        // 該当する年のデータを取得。月別の合計(sum)で取りたい
         BigDecimal[] monthlyDividend = getMonthlyDividend(year);
-        // 累計の配列に作り直す
         BigDecimal[] cumulativeDividend = getCumulativeDividend(monthlyDividend);
-        // コンマで連結する
-        return chartData;
+        return createChartData(cumulativeDividend);
     }
 
     /*
@@ -70,6 +67,21 @@ public class LineChartService {
         }
 
         return cumulativeDividend;
+    }
+
+    /**
+     * 受け取ったデータをコンマ区切りの文字列に合成して返す
+     * @param cumulativeDividend 合成したいデータ
+     * @return 合成した文字列 例）"1,2,3,4,5"
+     */
+    private String createChartData(BigDecimal[] cumulativeDividend) {
+        StringBuilder chartData = new StringBuilder();
+        chartData.append(cumulativeDividend[0].toString());
+        for (int i = 1; i < cumulativeDividend.length; i++) {
+            chartData.append(",");
+            chartData.append(cumulativeDividend[i].toString());
+        }
+        return chartData.toString();
     }
 
 }

--- a/src/main/java/com/example/divichart/service/LineChartService.java
+++ b/src/main/java/com/example/divichart/service/LineChartService.java
@@ -1,9 +1,18 @@
 package com.example.divichart.service;
 
+import com.example.divichart.repository.DividendHistoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.util.Calendar;
 
 @Service
 public class LineChartService {
+
+    @Autowired
+    DividendHistoryRepository repository;
 
     /*
      * @return result グラフ描画用データ
@@ -12,9 +21,37 @@ public class LineChartService {
 
         String chartData = "";
         // 該当する年のデータを取得。月別の合計(sum)で取りたい
+        BigDecimal[] monthlyDividendSum = getMonthlyDividendSum(year);
         // 累計の配列に作り直す
         // コンマで連結する
         return chartData;
+    }
+
+    /*
+     * 月別配当金額合計を取得する
+     */
+    public BigDecimal[] getMonthlyDividendSum(String year) {
+        BigDecimal[] monthlyDividendSum = new BigDecimal[12];
+
+        for (int i = 0; i < 12; i++) {
+
+            String startMonth = String.format("%02d", i+1);
+
+            Date startDate = Date.valueOf(year + "-" + startMonth + "-01");
+
+            Calendar calendar = Calendar.getInstance();
+            calendar.setTime(startDate);
+
+            calendar.add(Calendar.MONTH, 1); // 次月にする
+            calendar.add(Calendar.DATE, -1); // 1引いて月末にする
+
+            long timeInMilliSeconds = calendar.getTime().getTime();
+            Date endDate = new Date(timeInMilliSeconds);
+
+            BigDecimal dividendSum = repository.getDividendSum(startDate, endDate);
+            monthlyDividendSum[i] = dividendSum;
+        }
+        return monthlyDividendSum;
     }
 
 }

--- a/src/main/java/com/example/divichart/service/LineChartService.java
+++ b/src/main/java/com/example/divichart/service/LineChartService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.util.Calendar;
+import java.util.StringJoiner;
 
 @Service
 public class LineChartService {
@@ -69,16 +70,14 @@ public class LineChartService {
     }
 
     /**
-     * 受け取ったデータをコンマ区切りの文字列に合成して返す
-     * @param cumulativeDividend 合成したいデータ
+     * 受け取ったデータをグラフ描画用に合成する
+     * @param cumulativeDividend 合成したいデータ配列
      * @return 合成した文字列 例）"1,2,3,4,5"
      */
     private String createChartData(BigDecimal[] cumulativeDividend) {
-        StringBuilder chartData = new StringBuilder();
-        chartData.append(cumulativeDividend[0].toString());
-        for (int i = 1; i < cumulativeDividend.length; i++) {
-            chartData.append(",");
-            chartData.append(cumulativeDividend[i].toString());
+        StringJoiner chartData = new StringJoiner(",");
+        for (BigDecimal dividend : cumulativeDividend) {
+            chartData.add(dividend.toString());
         }
         return chartData.toString();
     }

--- a/src/main/java/com/example/divichart/service/LineChartService.java
+++ b/src/main/java/com/example/divichart/service/LineChartService.java
@@ -23,6 +23,7 @@ public class LineChartService {
         // 該当する年のデータを取得。月別の合計(sum)で取りたい
         BigDecimal[] monthlyDividendSum = getMonthlyDividendSum(year);
         // 累計の配列に作り直す
+        BigDecimal[] cumulativeDividend = getCumulativeDividend(monthlyDividendSum);
         // コンマで連結する
         return chartData;
     }
@@ -52,6 +53,23 @@ public class LineChartService {
             monthlyDividendSum[i] = dividendSum;
         }
         return monthlyDividendSum;
+    }
+
+    /**
+     * 累計額の配列にして返す
+     * @param monthlyDividendSum 月別配当
+     * @return cumulativeDividend 累計配当
+     */
+    private BigDecimal[] getCumulativeDividend(BigDecimal[] monthlyDividendSum) {
+        BigDecimal[] cumulativeDividend = new BigDecimal[12];
+        BigDecimal sum = new BigDecimal("0");
+
+        for (int i = 0; i < 12; i++) {
+            sum = sum.add(monthlyDividendSum[i]);
+            cumulativeDividend[i] = sum;
+        }
+
+        return cumulativeDividend;
     }
 
 }

--- a/src/main/java/com/example/divichart/service/LineChartService.java
+++ b/src/main/java/com/example/divichart/service/LineChartService.java
@@ -55,17 +55,16 @@ public class LineChartService {
     /**
      * 累計額の配列にして返す
      * @param monthlyDividend 月別配当
-     * @return cumulativeDividend 累計配当
+     * @return 累計配当
      */
     private BigDecimal[] getCumulativeDividend(BigDecimal[] monthlyDividend) {
-        BigDecimal[] cumulativeDividend = new BigDecimal[12];
-        BigDecimal sum = new BigDecimal("0");
-
-        for (int i = 0; i < monthlyDividend.length; i++) {
+        int arrayLength = monthlyDividend.length;
+        BigDecimal[] cumulativeDividend = new BigDecimal[arrayLength];
+        BigDecimal sum = BigDecimal.ZERO;
+        for (int i = 0; i < arrayLength; i++) {
             sum = sum.add(monthlyDividend[i]);
             cumulativeDividend[i] = sum;
         }
-
         return cumulativeDividend;
     }
 

--- a/src/main/java/com/example/divichart/service/LineChartService.java
+++ b/src/main/java/com/example/divichart/service/LineChartService.java
@@ -21,18 +21,18 @@ public class LineChartService {
 
         String chartData = "";
         // 該当する年のデータを取得。月別の合計(sum)で取りたい
-        BigDecimal[] monthlyDividendSum = getMonthlyDividendSum(year);
+        BigDecimal[] monthlyDividend = getMonthlyDividend(year);
         // 累計の配列に作り直す
-        BigDecimal[] cumulativeDividend = getCumulativeDividend(monthlyDividendSum);
+        BigDecimal[] cumulativeDividend = getCumulativeDividend(monthlyDividend);
         // コンマで連結する
         return chartData;
     }
 
     /*
-     * 月別配当金額合計を取得する
+     * 月別配当金額合計額を取得する
      */
-    public BigDecimal[] getMonthlyDividendSum(String year) {
-        BigDecimal[] monthlyDividendSum = new BigDecimal[12];
+    private BigDecimal[] getMonthlyDividend(String year) {
+        BigDecimal[] monthlyDividend = new BigDecimal[12];
 
         for (int i = 0; i < 12; i++) {
 
@@ -50,22 +50,22 @@ public class LineChartService {
             Date endDate = new Date(timeInMilliSeconds);
 
             BigDecimal dividendSum = repository.getDividendSum(startDate, endDate);
-            monthlyDividendSum[i] = dividendSum;
+            monthlyDividend[i] = dividendSum;
         }
-        return monthlyDividendSum;
+        return monthlyDividend;
     }
 
     /**
      * 累計額の配列にして返す
-     * @param monthlyDividendSum 月別配当
+     * @param monthlyDividend 月別配当
      * @return cumulativeDividend 累計配当
      */
-    private BigDecimal[] getCumulativeDividend(BigDecimal[] monthlyDividendSum) {
+    private BigDecimal[] getCumulativeDividend(BigDecimal[] monthlyDividend) {
         BigDecimal[] cumulativeDividend = new BigDecimal[12];
         BigDecimal sum = new BigDecimal("0");
 
-        for (int i = 0; i < 12; i++) {
-            sum = sum.add(monthlyDividendSum[i]);
+        for (int i = 0; i < monthlyDividend.length; i++) {
+            sum = sum.add(monthlyDividend[i]);
             cumulativeDividend[i] = sum;
         }
 

--- a/src/main/java/com/example/divichart/service/LineChartService.java
+++ b/src/main/java/com/example/divichart/service/LineChartService.java
@@ -1,0 +1,20 @@
+package com.example.divichart.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class LineChartService {
+
+    /*
+     * @return result グラフ描画用データ
+     */
+    public String getChartData(String year) {
+
+        String chartData = "";
+        // 該当する年のデータを取得。月別の合計(sum)で取りたい
+        // 累計の配列に作り直す
+        // コンマで連結する
+        return chartData;
+    }
+
+}

--- a/src/main/java/com/example/divichart/service/LineChartService.java
+++ b/src/main/java/com/example/divichart/service/LineChartService.java
@@ -5,8 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
-import java.sql.Date;
-import java.util.Calendar;
+import java.time.LocalDate;
 import java.util.StringJoiner;
 
 @Service
@@ -26,26 +25,20 @@ public class LineChartService {
         return createChartData(cumulativeDividend);
     }
 
-    /*
-     * 月別配当金額合計額を取得する
+    /**
+     * 月別配当金額を取得する
+     * @param year 対象年
+     * @return 月別配当配列
      */
     private BigDecimal[] getMonthlyDividend(String year) {
         BigDecimal[] monthlyDividend = new BigDecimal[12];
 
         for (int i = 0; i < 12; i++) {
+            int month = i + 1;
+            String formattedMonth = String.format("%02d", month);
 
-            String startMonth = String.format("%02d", i+1);
-
-            Date startDate = Date.valueOf(year + "-" + startMonth + "-01");
-
-            Calendar calendar = Calendar.getInstance();
-            calendar.setTime(startDate);
-
-            calendar.add(Calendar.MONTH, 1); // 次月にする
-            calendar.add(Calendar.DATE, -1); // 1引いて月末にする
-
-            long timeInMilliSeconds = calendar.getTime().getTime();
-            Date endDate = new Date(timeInMilliSeconds);
+            LocalDate startDate = LocalDate.parse(year + "-" + formattedMonth + "-01");
+            LocalDate endDate = startDate.plusMonths(1).minusDays(1);
 
             BigDecimal dividendSum = repository.getDividendSum(startDate, endDate);
             monthlyDividend[i] = dividendSum;

--- a/src/main/resources/static/css/lineChart.css
+++ b/src/main/resources/static/css/lineChart.css
@@ -1,0 +1,13 @@
+/* 累計配当グラフ用CSS */
+/* PC用 */
+@media (min-width: 767px) {
+    .chart-container {
+        height: 600px;
+    }
+}
+/* スマホ用 */
+@media (max-width: 768px) {
+    .chart-container {
+        height: 400px;
+    }
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -8,5 +8,6 @@
     <h1>トップ画面</h1>
     <p><a th:href="@{/operation}">データ操作画面</a></p>
     <p><a th:href="@{/list}">配当履歴一覧画面</a></p>
+    <p><a th:href="@{/lineChart}">累計配当グラフ</a></p>
 </body>
 </html>

--- a/src/main/resources/templates/lineChart.html
+++ b/src/main/resources/templates/lineChart.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="https://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>累計配当グラフ覧</title>
+</head>
+<body>
+<h1>累計配当グラフ</h1>
+<p><a th:href="@{/index}">TOP画面</a></p>
+</body>
+</html>

--- a/src/main/resources/templates/lineChart.html
+++ b/src/main/resources/templates/lineChart.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>累計配当グラフ覧</title>
+    <link th:href="@{/css/lineChart.css}" rel="styleSheet">
 </head>
 <body>
     <h1>累計配当グラフ</h1>

--- a/src/main/resources/templates/lineChart.html
+++ b/src/main/resources/templates/lineChart.html
@@ -5,7 +5,46 @@
     <title>累計配当グラフ覧</title>
 </head>
 <body>
-<h1>累計配当グラフ</h1>
-<p><a th:href="@{/index}">TOP画面</a></p>
+    <h1>累計配当グラフ</h1>
+    <p><a th:href="@{/index}">TOP画面</a></p>
+    <div class="chart-container">
+        <canvas id="lineChart"></canvas>
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.bundle.js"></script>
+    <script>
+        var ctx = document.getElementById("lineChart");
+        var myLineChart = new Chart(ctx, {
+            type : 'line',
+            data : {
+                labels : [ '2020年1月', '2月', '3月', '4月', '5月', '6月'
+                    , '7月', '8月', '9月', '10月', '11月', '12月'],
+                datasets : [ {
+                    label : '累計配当受取額(ドル）',
+                    data : [ [[${chartData}]] ],
+                    borderColor : "rgba(0,0,255,1)",
+                    backgroundColor : "rgba(0,0,0,0)"
+                } ],
+            },
+            options : {
+                title : {
+                    display : true,
+                    text : '配当推移（2020年1月~2020年12月）'
+                },
+                scales : {
+                    yAxes : [ {
+                        ticks : {
+                            suggestedMax : 40,
+                            suggestedMin : 0,
+                            stepSize : 10,
+                            callback : function(value, index, values) {
+                                return value + 'ドル'
+                            }
+                        }
+                    } ]
+                },
+                maintainAspectRatio: false,
+            }
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
# 概要
- 指定年の累計配当金額を線グラフで表示できるようにする

# 処理内容
1. 指定年の月別配当金額を配列で取得する
2. 累計配当金額の配列に直す（例：1月の配当金が10$の時、2月は2月の配当金＋1月の配当金10$）
3. 累計配当金額の配列をチャート表示用に加工して文字列にする
4. View側に渡して線グラフとして表示

# 本PRで対応していないこと
- 表示対象の年を指定できるようにする
  - 現状では2020年で固定されている
  - 任意の念を表示できるようにしたい
- 1年以上の期間を表示できるようにする

上記は後ほど検討したうえで可能なタイミングで実装する