### PR TITLE
累計配当グラフは参照のみなので認証外にする

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>com.example</groupId>
 	<artifactId>divichart</artifactId>
-	<version>0.6.0</version>
+	<version>0.6.1</version>
 	<name>divichart</name>
 	<properties>
 		<java.version>11</java.version>

--- a/src/main/java/com/example/divichart/configuration/WebSecurityConfig.java
+++ b/src/main/java/com/example/divichart/configuration/WebSecurityConfig.java
@@ -28,6 +28,7 @@ public class WebSecurityConfig {
                 .mvcMatchers("/"
                         ,"/index"
                         ,"/login"
+                        ,"/lineChart"
                 ).permitAll()
                 .anyRequest().authenticated();
 

--- a/src/main/java/com/example/divichart/configuration/WebSecurityConfig.java
+++ b/src/main/java/com/example/divichart/configuration/WebSecurityConfig.java
@@ -25,7 +25,10 @@ public class WebSecurityConfig {
 
         // 認証・認可設定
         http.authorizeRequests()
-                .mvcMatchers("/", "/index", "/login").permitAll()
+                .mvcMatchers("/"
+                        ,"/index"
+                        ,"/login"
+                ).permitAll()
                 .anyRequest().authenticated();
 
         // ログイン設定

--- a/src/main/java/com/example/divichart/configuration/WebSecurityConfig.java
+++ b/src/main/java/com/example/divichart/configuration/WebSecurityConfig.java
@@ -28,6 +28,7 @@ public class WebSecurityConfig {
                 .mvcMatchers("/"
                         ,"/index"
                         ,"/login"
+                        ,"/css/**"
                         ,"/lineChart"
                 ).permitAll()
                 .anyRequest().authenticated();


### PR DESCRIPTION
累計配当グラフは認証なしでも表示できるようにする想定だったが、
失念していたため修正する。

更新系処理は認証をかけていく方針
参照系のみは基本的に認証不要にしたい