### PR TITLE
月別配当グラフ追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>com.example</groupId>
 	<artifactId>divichart</artifactId>
-	<version>0.6.1</version>
+	<version>0.7.0</version>
 	<name>divichart</name>
 	<properties>
 		<java.version>11</java.version>

--- a/src/main/java/com/example/divichart/configuration/WebSecurityConfig.java
+++ b/src/main/java/com/example/divichart/configuration/WebSecurityConfig.java
@@ -30,6 +30,7 @@ public class WebSecurityConfig {
                         ,"/login"
                         ,"/css/**"
                         ,"/lineChart"
+                        ,"/barChart"
                 ).permitAll()
                 .anyRequest().authenticated();
 

--- a/src/main/java/com/example/divichart/controller/BarChartController.java
+++ b/src/main/java/com/example/divichart/controller/BarChartController.java
@@ -9,9 +9,8 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-
 @Controller
-@RequestMapping( "/barChart" )
+@RequestMapping("/barChart")
 public class BarChartController {
 
     @Autowired

--- a/src/main/java/com/example/divichart/controller/BarChartController.java
+++ b/src/main/java/com/example/divichart/controller/BarChartController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -19,10 +20,19 @@ public class BarChartController {
     private static final Logger log = LoggerFactory.getLogger(BarChartController.class);
 
     @GetMapping
-    public String index(Model model) {
+    public String index(Model model,
+                        @ModelAttribute("targetYear") String targetYear) {
         log.debug("月別配当グラフ表示");
-        String chartData = service.getChartData("2020");
+
+        String[] recentYears = service.getRecentYears();
+        model.addAttribute("recentYears", recentYears);
+
+        if (targetYear.isEmpty()) targetYear = recentYears[0];
+        model.addAttribute("targetYear", targetYear);
+
+        String chartData = service.getChartData(targetYear);
         model.addAttribute("chartData", chartData);
+
         return "barChart";
     }
 

--- a/src/main/java/com/example/divichart/controller/BarChartController.java
+++ b/src/main/java/com/example/divichart/controller/BarChartController.java
@@ -1,8 +1,11 @@
 package com.example.divichart.controller;
 
+import com.example.divichart.service.BarChartService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -11,11 +14,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping( "/barChart" )
 public class BarChartController {
 
+    @Autowired
+    BarChartService service;
+
     private static final Logger log = LoggerFactory.getLogger(BarChartController.class);
 
     @GetMapping
-    public String index() {
+    public String index(Model model) {
         log.debug("月別配当グラフ表示");
+        String chartData = service.getChartData("2020");
+        model.addAttribute("chartData", chartData);
         return "barChart";
     }
 

--- a/src/main/java/com/example/divichart/controller/BarChartController.java
+++ b/src/main/java/com/example/divichart/controller/BarChartController.java
@@ -1,0 +1,22 @@
+package com.example.divichart.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+
+@Controller
+@RequestMapping( "/barChart" )
+public class BarChartController {
+
+    private static final Logger log = LoggerFactory.getLogger(BarChartController.class);
+
+    @GetMapping
+    public String index() {
+        log.debug("月別配当グラフ表示");
+        return "barChart";
+    }
+
+}

--- a/src/main/java/com/example/divichart/service/BarChartService.java
+++ b/src/main/java/com/example/divichart/service/BarChartService.java
@@ -1,0 +1,27 @@
+package com.example.divichart.service;
+
+import com.example.divichart.repository.DividendHistoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.StringJoiner;
+
+@Service
+public class BarChartService extends BasicChartService{
+
+    @Autowired
+    DividendHistoryRepository repository;
+
+    /**
+     * グラフ描画用に、指定年の月別配当データを取得する
+     * @param year データ作成対象年
+     * @return グラフ描画用文字列
+     */
+    public String getChartData(String year) {
+        BigDecimal[] monthlyDividend = getMonthlyDividend(year);
+        return createChartData(monthlyDividend);
+    }
+
+}

--- a/src/main/java/com/example/divichart/service/BarChartService.java
+++ b/src/main/java/com/example/divichart/service/BarChartService.java
@@ -1,21 +1,15 @@
 package com.example.divichart.service;
 
-import com.example.divichart.repository.DividendHistoryRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.StringJoiner;
 
 @Service
-public class BarChartService extends BasicChartService{
-
-    @Autowired
-    DividendHistoryRepository repository;
+public class BarChartService extends BasicChartService {
 
     /**
      * グラフ描画用に、指定年の月別配当データを取得する
+     *
      * @param year データ作成対象年
      * @return グラフ描画用文字列
      */

--- a/src/main/java/com/example/divichart/service/BasicChartService.java
+++ b/src/main/java/com/example/divichart/service/BasicChartService.java
@@ -1,0 +1,81 @@
+package com.example.divichart.service;
+
+import com.example.divichart.repository.DividendHistoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.StringJoiner;
+
+@Service
+public class BasicChartService {
+
+    @Autowired
+    DividendHistoryRepository repository;
+
+    /**
+     * 月別配当金額を取得する
+     * @param year 対象年
+     * @return 月別配当配列
+     */
+    protected BigDecimal[] getMonthlyDividend(String year) {
+        BigDecimal[] monthlyDividend = new BigDecimal[12];
+
+        for (int i = 0; i < 12; i++) {
+            int month = i + 1;
+            String formattedMonth = String.format("%02d", month);
+
+            LocalDate startDate = LocalDate.parse(year + "-" + formattedMonth + "-01");
+            LocalDate endDate = startDate.plusMonths(1).minusDays(1);
+
+            BigDecimal dividendSum = repository.getDividendSum(startDate, endDate);
+            monthlyDividend[i] = dividendSum;
+        }
+        return monthlyDividend;
+    }
+
+    /**
+     * 受け取ったデータをグラフ描画用に合成する
+     * @param cumulativeDividend 合成したいデータ配列
+     * @return 合成した文字列 例）"1,2,3,4,5"
+     */
+    protected String createChartData(BigDecimal[] cumulativeDividend) {
+        StringJoiner chartData = new StringJoiner(",");
+        for (BigDecimal dividend : cumulativeDividend) {
+            chartData.add(dividend.toString());
+        }
+        return chartData.toString();
+    }
+
+    /**
+     * 今年も含めて過去5年分の年（西暦）を取得する
+     * @return 年を表す配列
+     */
+    public String[] getRecentYears() {
+        String[] recentYears = new String[5];
+        int currentYear = LocalDate.now().getYear();
+
+        for (int i = 0; i < 5; i++) {
+            recentYears[i] = String.valueOf(currentYear - i);
+        }
+        return recentYears;
+    }
+    
+    /**
+     * 指定された数の最近の年を取得する。
+     *
+     * @param numOfYears 取得する年数
+     * @return 最近の年の文字列配列
+     */
+    public String[] getRecentYears(int numOfYears) {
+        String[] recentYears = new String[numOfYears];
+        int currentYear = LocalDate.now().getYear();
+
+        for (int i = 0; i < numOfYears; i++) {
+            recentYears[i] = String.valueOf(currentYear - i);
+        }
+        return recentYears;
+    }
+
+}

--- a/src/main/resources/static/css/basicChart.css
+++ b/src/main/resources/static/css/basicChart.css
@@ -1,0 +1,13 @@
+/* チャート用基本CSS */
+/* PC向け */
+@media (min-width: 767px) {
+    .chart-container {
+        height: 600px;
+    }
+}
+/* スマホ向け */
+@media (max-width: 768px) {
+    .chart-container {
+        height: 400px;
+    }
+}

--- a/src/main/resources/templates/barChart.html
+++ b/src/main/resources/templates/barChart.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="https://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>月別配当グラフ</title>
+</head>
+<body>
+    <h1>月別配当グラフ</h1>
+    <p><a th:href="@{/index}">TOP画面</a></p>
+</body>
+</html>

--- a/src/main/resources/templates/barChart.html
+++ b/src/main/resources/templates/barChart.html
@@ -8,6 +8,14 @@
 <body>
     <h1>月別配当グラフ</h1>
     <p><a th:href="@{/index}">TOP画面</a></p>
+    <form th:action="@{/barChart}" method="get">
+        <p>対象年：
+            <select name="targetYear">
+                <option th:each="year : ${recentYears}" th:value="${year}" th:text="${year}" th:selected="${year == targetYear}"></option>
+            </select>
+            <input type="submit" value="表示" />
+        </p>
+    </form>
     <div class="chart-container">
         <canvas id="barChart"></canvas>
     </div>

--- a/src/main/resources/templates/barChart.html
+++ b/src/main/resources/templates/barChart.html
@@ -3,9 +3,48 @@
 <head>
     <meta charset="UTF-8">
     <title>月別配当グラフ</title>
+    <link th:href="@{/css/basicChart.css}" rel="styleSheet">
 </head>
 <body>
     <h1>月別配当グラフ</h1>
     <p><a th:href="@{/index}">TOP画面</a></p>
+    <div class="chart-container">
+        <canvas id="barChart"></canvas>
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.bundle.js"></script>
+    <script>
+        var ctx = document.getElementById("barChart");
+        var myBarChart = new Chart(ctx, {
+            type : 'bar',
+            data : {
+                labels : [ "1月","2月","3月","4月","5月","6月","7月",
+                      "8月", "9月", "10月", "11月", "12月" ],
+                datasets : [ {
+                    label : '配当受取額',
+                    data : [ [[${chartData}]] ],
+                    backgroundColor : "rgba(130,201,169,0.5)"
+                } ]
+            },
+            options : {
+                title : {
+                    display : true,
+                    text : '月別配当受取額'
+                },
+                scales : {
+                    yAxes : [ {
+                        ticks : {
+                            suggestedMax : 100,
+                            suggestedMin : 0,
+                            stepSize : 10,
+                            callback : function(value, index, values) {
+                                return value + 'ドル'
+                            }
+                        }
+                    } ]
+                },
+                maintainAspectRatio: false,
+            }
+        });
+    </script>
 </body>
 </html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -9,5 +9,6 @@
     <p><a th:href="@{/operation}">データ操作画面</a></p>
     <p><a th:href="@{/list}">配当履歴一覧画面</a></p>
     <p><a th:href="@{/lineChart}">累計配当グラフ</a></p>
+    <p><a th:href="@{/barChart}">月別配当グラフ</a></p>
 </body>
 </html>


### PR DESCRIPTION
# 内容
- 指定年の月別配当金額を棒グラフで表示できるようにした
- 他のチャート表示と共通化できそうなところ（CSS・ロジック）は共通化することにした
  - もし使いにくいようであれば依存関係を解消して分離させる方針

# 本PRで対応しなかったこと
- 前年との並列表示
  - 前の年の受取額と並べて比較できるようにしたいが本ＰＲでは対応していない