### PR TITLE
getLoggerの引数のクラス名取得方法変更

### DIFF
--- a/src/main/java/click/divichart/controller/BarChartController.java
+++ b/src/main/java/click/divichart/controller/BarChartController.java
@@ -14,7 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/barChart")
 public class BarChartController {
 
-    private static final Logger log = LoggerFactory.getLogger(BarChartController.class);
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
     @Autowired
     BarChartService service;
 

--- a/src/main/java/click/divichart/controller/IndexController.java
+++ b/src/main/java/click/divichart/controller/IndexController.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 @RequestMapping("/index")
 public class IndexController {
 
-    private static final Logger log = LoggerFactory.getLogger(IndexController.class);
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @GetMapping
     public String index() {

--- a/src/main/java/click/divichart/controller/LineChartController.java
+++ b/src/main/java/click/divichart/controller/LineChartController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/lineChart")
 public class LineChartController {
 
-    private static final Logger log = LoggerFactory.getLogger(LineChartController.class);
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @Autowired
     LineChartService service;

--- a/src/main/java/click/divichart/controller/ListController.java
+++ b/src/main/java/click/divichart/controller/ListController.java
@@ -22,7 +22,7 @@ import java.sql.Date;
 @RequestMapping("/list")
 public class ListController {
 
-    private static final Logger log = LoggerFactory.getLogger(ListController.class);
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @Autowired
     ListService service;

--- a/src/main/java/click/divichart/controller/PieChartController.java
+++ b/src/main/java/click/divichart/controller/PieChartController.java
@@ -14,7 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping({"/", "/pieChart"})
 public class PieChartController {
 
-    private static final Logger log = LoggerFactory.getLogger(PieChartController.class);
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    
     @Autowired
     PieChartService service;
 

--- a/src/main/java/click/divichart/service/ListService.java
+++ b/src/main/java/click/divichart/service/ListService.java
@@ -22,7 +22,7 @@ import java.util.List;
 @Service
 public class ListService {
 
-    private static final Logger log = LoggerFactory.getLogger(ListService.class);
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @Autowired
     DividendHistoryRepository repository;


### PR DESCRIPTION
コピーする場面でmissが発生する原因になるため、
thisを使って統一的に取得できるようにする。