### PR TITLE
Chart.jsを最新verに更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>click.divichart</groupId>
 	<artifactId>divichart</artifactId>
-	<version>2.3.1</version>
+	<version>2.4.0</version>
 	<name>divichart</name>
 	<properties>
 		<java.version>17</java.version>

--- a/src/main/resources/templates/barChart.html
+++ b/src/main/resources/templates/barChart.html
@@ -23,7 +23,8 @@
     <div class="chart-container">
         <canvas id="barChart"></canvas>
     </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.bundle.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
     <script>
         var ctx = document.getElementById("barChart");
         var myBarChart = new Chart(ctx, {
@@ -38,21 +39,23 @@
                 } ]
             },
             options : {
-                title : {
-                    display : true,
-                    text : '月別配当受取額'
+                plugins : {
+                    title : {
+                        display : true,
+                        text : '月別配当受取額'
+                    },
                 },
                 scales : {
-                    yAxes : [ {
+                    y : {
+                        suggestedMax : 100,
+                        suggestedMin : 0,
                         ticks : {
-                            suggestedMax : 100,
-                            suggestedMin : 0,
                             stepSize : 10,
                             callback : function(value, index, values) {
                                 return value + 'ドル'
                             }
                         }
-                    } ]
+                    }
                 },
                 maintainAspectRatio: false,
             }

--- a/src/main/resources/templates/lineChart.html
+++ b/src/main/resources/templates/lineChart.html
@@ -23,41 +23,52 @@
     <div class="chart-container">
         <canvas id="lineChart"></canvas>
     </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.4/Chart.bundle.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
     <script>
-        var ctx = document.getElementById("lineChart");
-        var myLineChart = new Chart(ctx, {
-            type : 'line',
-            data : {
-                labels : [ '[[${targetYear}]]年1月', '2月', '3月', '4月', '5月', '6月'
-                    , '7月', '8月', '9月', '10月', '11月', '12月'],
-                datasets : [ {
-                    label : '累計配当受取額(ドル）',
-                    data : [ [[${chartData}]] ],
-                    borderColor : "rgba(0,0,255,1)",
-                    backgroundColor : "rgba(0,0,0,0)"
-                } ],
-            },
-            options : {
-                title : {
-                    display : true,
-                    text : '配当推移（[[${targetYear}]]年1月~[[${targetYear}]]年12月）'
+        let ctx = document.getElementById( "lineChart" );
+        let chart = new Chart( ctx,
+            {
+                type: 'line',
+                data: {
+                    labels: [
+                        '[[${targetYear}]]年1月',
+                        '2月', '3月', '4月', '5月', '6月',
+                        '7月', '8月', '9月', '10月', '11月', '12月'
+                    ],
+                    datasets: [
+                        {
+                            label: '累計配当受取額(ドル）',
+                            data: [ [[${chartData}]] ],
+                            borderColor: "rgba( 0, 0, 255, 1 )",
+                            backgroundColor: "rgba( 0, 0, 0, 0 )",
+                            lineTension: 0.4,
+                        },
+                    ],
                 },
-                scales : {
-                    yAxes : [ {
-                        ticks : {
-                            suggestedMax : 40,
-                            suggestedMin : 0,
-                            stepSize : 10,
-                            callback : function(value, index, values) {
-                                return value + 'ドル'
-                            }
+                options: {
+                    plugins: {
+                        title: {
+                            display: true,
+                            text: '配当推移（[[${targetYear}]]年1月~[[${targetYear}]]年12月）'
                         }
-                    } ]
-                },
-                maintainAspectRatio: false,
-            }
-        });
+                    },
+                    scales: {
+                        y: {
+                            suggestedMax: 40,
+                            suggestedMin: 0,
+                            ticks: {
+                                stepSize: 10,
+                                callback: function(value, index, values) {
+                                    return value + 'ドル'
+                                }
+                            }
+                        },
+                    },
+                    maintainAspectRatio: false,
+                }
+            },
+        );
     </script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
             integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"

--- a/src/main/resources/templates/pieChart.html
+++ b/src/main/resources/templates/pieChart.html
@@ -25,7 +25,8 @@
     <div class="chart-container">
         <canvas id="pieChart"></canvas>
     </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.bundle.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
     <script>
         var ctx = document.getElementById("pieChart");
         var pieChart = new Chart(ctx, {
@@ -40,9 +41,11 @@
                 } ]
             },
             options : {
-                title : {
-                    display : true,
-                    text : '銘柄別  配当受取額割合'
+                plugins: {
+                    title: {
+                        display: true,
+                        text: '銘柄別  配当受取額割合'
+                    }
                 },
                 maintainAspectRatio: false,
             }


### PR DESCRIPTION
Chart.js 4.4.0 が最新なので、そこまでバージョンを上げる。
内容は変えないが、文法が変わる部分は対応する。