### PR TITLE
配当割合グラフで表示する銘柄数を制限する

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>click.divichart</groupId>
 	<artifactId>divichart</artifactId>
-	<version>2.7.0</version>
+	<version>2.8.0</version>
 	<name>divichart</name>
 	<properties>
 		<java.version>17</java.version>

--- a/src/main/java/click/divichart/bean/dto/DividendSummaryDto.java
+++ b/src/main/java/click/divichart/bean/dto/DividendSummaryDto.java
@@ -10,11 +10,11 @@ import java.math.BigDecimal;
 @Getter
 @Setter
 @NoArgsConstructor
-public class DividendTotalForStockDto implements Serializable {
+public class DividendSummaryDto implements Serializable {
     private String tickerSymbol;
     private BigDecimal amountReceived;
 
-    public DividendTotalForStockDto(String tickerSymbol, BigDecimal amountReceived) {
+    public DividendSummaryDto(String tickerSymbol, BigDecimal amountReceived) {
         this.tickerSymbol = tickerSymbol;
         this.amountReceived = amountReceived;
     }

--- a/src/main/java/click/divichart/bean/dto/DividendTotalForStockDto.java
+++ b/src/main/java/click/divichart/bean/dto/DividendTotalForStockDto.java
@@ -1,0 +1,21 @@
+package click.divichart.bean.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class DividendTotalForStockDto implements Serializable {
+    private String tickerSymbol;
+    private BigDecimal amountReceived;
+
+    public DividendTotalForStockDto(String tickerSymbol, BigDecimal amountReceived) {
+        this.tickerSymbol = tickerSymbol;
+        this.amountReceived = amountReceived;
+    }
+}

--- a/src/main/java/click/divichart/service/PieChartService.java
+++ b/src/main/java/click/divichart/service/PieChartService.java
@@ -56,7 +56,7 @@ public class PieChartService extends BasicChartService {
                 );
             }
         }
-        if(!other.getAmountReceived().equals(BigDecimal.ZERO)){
+        if(other.getAmountReceived().compareTo(BigDecimal.ZERO) != 0){
             dividendTotalForStockDtoList.add(other);
         }
         return dividendTotalForStockDtoList;

--- a/src/main/java/click/divichart/service/PieChartService.java
+++ b/src/main/java/click/divichart/service/PieChartService.java
@@ -1,6 +1,6 @@
 package click.divichart.service;
 
-import click.divichart.bean.dto.DividendTotalForStockDto;
+import click.divichart.bean.dto.DividendSummaryDto;
 import click.divichart.bean.dto.PieChartDto;
 import click.divichart.repository.DividendHistoryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,53 +30,53 @@ public class PieChartService extends BasicChartService {
         LocalDate startDate = LocalDate.parse(year + "-01-01");
         LocalDate endDate = startDate.plusYears(1).minusDays(1);
         List<Object[]> dividendSummaryList = repository.getDividendTotalForStock(startDate, endDate);
-        List<DividendTotalForStockDto> dividendTotalForStockDtoList = dataFormatting(dividendSummaryList);
+        List<DividendSummaryDto> dividendSummaryDtoList = dataFormatting(dividendSummaryList);
 
-        return createChartData(dividendTotalForStockDtoList);
+        return createChartData(dividendSummaryDtoList);
     }
 
-    List<DividendTotalForStockDto> dataFormatting(List<Object[]> dividendSummaryList) {
+    List<DividendSummaryDto> dataFormatting(List<Object[]> dividendSummaryList) {
 
-        List<DividendTotalForStockDto> dividendTotalForStockDtoList = new ArrayList<>();
-        DividendTotalForStockDto other = new DividendTotalForStockDto(
+        List<DividendSummaryDto> dividendSummaryDtoList = new ArrayList<>();
+        DividendSummaryDto other = new DividendSummaryDto(
                 "その他",
                 BigDecimal.ZERO
         );
 
         for (Object[] dividendSummary : dividendSummaryList) {
-            DividendTotalForStockDto dividendTotalForStockDto = new DividendTotalForStockDto(
+            DividendSummaryDto dividendSummaryDto = new DividendSummaryDto(
                     (String) dividendSummary[0],
                     (BigDecimal) dividendSummary[1]
             );
-            if (dividendTotalForStockDtoList.size() < MAX_DISPLAYED_STOCKS) {
-                dividendTotalForStockDtoList.add(dividendTotalForStockDto);
+            if (dividendSummaryDtoList.size() < MAX_DISPLAYED_STOCKS) {
+                dividendSummaryDtoList.add(dividendSummaryDto);
             } else {
                 other.setAmountReceived(
                         other.getAmountReceived().add(
-                                dividendTotalForStockDto.getAmountReceived()
+                                dividendSummaryDto.getAmountReceived()
                         )
                 );
             }
         }
         if (other.getAmountReceived().compareTo(BigDecimal.ZERO) != 0) {
-            dividendTotalForStockDtoList.add(other);
+            dividendSummaryDtoList.add(other);
         }
-        return dividendTotalForStockDtoList;
+        return dividendSummaryDtoList;
     }
 
     /**
      * 配当情報からグラフ描画用のデータを生成する
      *
-     * @param dividendTotalForStockDtoList 配当情報
+     * @param dividendSummaryDtoList 配当情報
      * @return グラフ描画用文字列配列
      */
-    PieChartDto createChartData(List<DividendTotalForStockDto> dividendTotalForStockDtoList) {
+    PieChartDto createChartData(List<DividendSummaryDto> dividendSummaryDtoList) {
         StringJoiner tickerSymbolData = new StringJoiner("\",\"", "\"", "\"");
         StringJoiner amountReceivedData = new StringJoiner(",");
 
-        for (DividendTotalForStockDto dividendTotalForStockDto : dividendTotalForStockDtoList) {
-            String tickerSymbol = dividendTotalForStockDto.getTickerSymbol();
-            BigDecimal amountReceived = dividendTotalForStockDto.getAmountReceived();
+        for (DividendSummaryDto dividendSummaryDto : dividendSummaryDtoList) {
+            String tickerSymbol = dividendSummaryDto.getTickerSymbol();
+            BigDecimal amountReceived = dividendSummaryDto.getAmountReceived();
 
             tickerSymbolData.add(tickerSymbol);
             amountReceivedData.add(amountReceived.toString());

--- a/src/main/java/click/divichart/service/PieChartService.java
+++ b/src/main/java/click/divichart/service/PieChartService.java
@@ -41,29 +41,36 @@ public class PieChartService extends BasicChartService {
      * @return 整形された配当の集計情報
      */
     List<DividendSummaryDto> formatData(List<Object[]> dividendSummaryList) {
-
         List<DividendSummaryDto> dividendSummaryDtoList = new ArrayList<>();
         DividendSummaryDto others = new DividendSummaryDto("その他", BigDecimal.ZERO);
 
         for (Object[] dividendSummary : dividendSummaryList) {
-            DividendSummaryDto dividendSummaryDto = new DividendSummaryDto(
-                    (String) dividendSummary[0],
-                    (BigDecimal) dividendSummary[1]
-            );
+            String stockName = (String) dividendSummary[0];
+            BigDecimal amountReceived = (BigDecimal) dividendSummary[1];
+
+            DividendSummaryDto dividendSummaryDto = new DividendSummaryDto(stockName, amountReceived);
+
             if (dividendSummaryDtoList.size() < MAX_DISPLAYED_STOCKS) {
                 dividendSummaryDtoList.add(dividendSummaryDto);
             } else {
-                others.setAmountReceived(
-                        others.getAmountReceived().add(
-                                dividendSummaryDto.getAmountReceived()
-                        )
-                );
+                addToOthers(others, dividendSummaryDto);
             }
         }
         if (others.getAmountReceived().compareTo(BigDecimal.ZERO) != 0) {
             dividendSummaryDtoList.add(others);
         }
         return dividendSummaryDtoList;
+    }
+
+    /***
+     * その他の配当情報に加算
+     * @param others その他の配当情報
+     * @param dividendSummaryDto 加算したい配当情報
+     */
+    private void addToOthers(DividendSummaryDto others, DividendSummaryDto dividendSummaryDto) {
+        BigDecimal currentAmountReceived = others.getAmountReceived();
+        BigDecimal newAmountReceived = currentAmountReceived.add(dividendSummaryDto.getAmountReceived());
+        others.setAmountReceived(newAmountReceived);
     }
 
     /**

--- a/src/main/java/click/divichart/service/PieChartService.java
+++ b/src/main/java/click/divichart/service/PieChartService.java
@@ -38,7 +38,7 @@ public class PieChartService extends BasicChartService {
     List<DividendSummaryDto> dataFormatting(List<Object[]> dividendSummaryList) {
 
         List<DividendSummaryDto> dividendSummaryDtoList = new ArrayList<>();
-        DividendSummaryDto other = new DividendSummaryDto(
+        DividendSummaryDto others = new DividendSummaryDto(
                 "その他",
                 BigDecimal.ZERO
         );
@@ -51,15 +51,15 @@ public class PieChartService extends BasicChartService {
             if (dividendSummaryDtoList.size() < MAX_DISPLAYED_STOCKS) {
                 dividendSummaryDtoList.add(dividendSummaryDto);
             } else {
-                other.setAmountReceived(
-                        other.getAmountReceived().add(
+                others.setAmountReceived(
+                        others.getAmountReceived().add(
                                 dividendSummaryDto.getAmountReceived()
                         )
                 );
             }
         }
-        if (other.getAmountReceived().compareTo(BigDecimal.ZERO) != 0) {
-            dividendSummaryDtoList.add(other);
+        if (others.getAmountReceived().compareTo(BigDecimal.ZERO) != 0) {
+            dividendSummaryDtoList.add(others);
         }
         return dividendSummaryDtoList;
     }

--- a/src/main/java/click/divichart/service/PieChartService.java
+++ b/src/main/java/click/divichart/service/PieChartService.java
@@ -38,10 +38,7 @@ public class PieChartService extends BasicChartService {
     List<DividendSummaryDto> dataFormatting(List<Object[]> dividendSummaryList) {
 
         List<DividendSummaryDto> dividendSummaryDtoList = new ArrayList<>();
-        DividendSummaryDto others = new DividendSummaryDto(
-                "その他",
-                BigDecimal.ZERO
-        );
+        DividendSummaryDto others = new DividendSummaryDto("その他", BigDecimal.ZERO);
 
         for (Object[] dividendSummary : dividendSummaryList) {
             DividendSummaryDto dividendSummaryDto = new DividendSummaryDto(

--- a/src/main/java/click/divichart/service/PieChartService.java
+++ b/src/main/java/click/divichart/service/PieChartService.java
@@ -33,7 +33,7 @@ public class PieChartService extends BasicChartService {
         return createChartData(dividendTotalForStockDtoList);
     }
 
-    List<DividendTotalForStockDto> dataFormatting(List<Object[]> dividendSummaryList){
+    List<DividendTotalForStockDto> dataFormatting(List<Object[]> dividendSummaryList) {
 
         List<DividendTotalForStockDto> dividendTotalForStockDtoList = new ArrayList<>();
         DividendTotalForStockDto other = new DividendTotalForStockDto(
@@ -46,9 +46,9 @@ public class PieChartService extends BasicChartService {
                     (String) dividendSummary[0],
                     (BigDecimal) dividendSummary[1]
             );
-            if(dividendTotalForStockDtoList.size() < 15){
+            if (dividendTotalForStockDtoList.size() < 15) {
                 dividendTotalForStockDtoList.add(dividendTotalForStockDto);
-            }else{
+            } else {
                 other.setAmountReceived(
                         other.getAmountReceived().add(
                                 dividendTotalForStockDto.getAmountReceived()
@@ -56,7 +56,7 @@ public class PieChartService extends BasicChartService {
                 );
             }
         }
-        if(other.getAmountReceived().compareTo(BigDecimal.ZERO) != 0){
+        if (other.getAmountReceived().compareTo(BigDecimal.ZERO) != 0) {
             dividendTotalForStockDtoList.add(other);
         }
         return dividendTotalForStockDtoList;

--- a/src/main/java/click/divichart/service/PieChartService.java
+++ b/src/main/java/click/divichart/service/PieChartService.java
@@ -15,6 +15,8 @@ import java.util.StringJoiner;
 @Service
 public class PieChartService extends BasicChartService {
 
+    private static final int MAX_DISPLAYED_STOCKS = 15;
+
     @Autowired
     DividendHistoryRepository repository;
 
@@ -46,7 +48,7 @@ public class PieChartService extends BasicChartService {
                     (String) dividendSummary[0],
                     (BigDecimal) dividendSummary[1]
             );
-            if (dividendTotalForStockDtoList.size() < 15) {
+            if (dividendTotalForStockDtoList.size() < MAX_DISPLAYED_STOCKS) {
                 dividendTotalForStockDtoList.add(dividendTotalForStockDto);
             } else {
                 other.setAmountReceived(

--- a/src/main/java/click/divichart/service/PieChartService.java
+++ b/src/main/java/click/divichart/service/PieChartService.java
@@ -37,6 +37,7 @@ public class PieChartService extends BasicChartService {
 
     /**
      * 配当の集計情報を整形して、小さいデータはその他にまとめる
+     *
      * @param dividendSummaryList 配当の集計情報
      * @return 整形された配当の集計情報
      */

--- a/src/main/java/click/divichart/service/PieChartService.java
+++ b/src/main/java/click/divichart/service/PieChartService.java
@@ -30,12 +30,12 @@ public class PieChartService extends BasicChartService {
         LocalDate startDate = LocalDate.parse(year + "-01-01");
         LocalDate endDate = startDate.plusYears(1).minusDays(1);
         List<Object[]> dividendSummaryList = repository.getDividendTotalForStock(startDate, endDate);
-        List<DividendSummaryDto> dividendSummaryDtoList = dataFormatting(dividendSummaryList);
+        List<DividendSummaryDto> dividendSummaryDtoList = formatData(dividendSummaryList);
 
         return createChartData(dividendSummaryDtoList);
     }
 
-    List<DividendSummaryDto> dataFormatting(List<Object[]> dividendSummaryList) {
+    List<DividendSummaryDto> formatData(List<Object[]> dividendSummaryList) {
 
         List<DividendSummaryDto> dividendSummaryDtoList = new ArrayList<>();
         DividendSummaryDto others = new DividendSummaryDto("その他", BigDecimal.ZERO);

--- a/src/main/java/click/divichart/service/PieChartService.java
+++ b/src/main/java/click/divichart/service/PieChartService.java
@@ -1,5 +1,6 @@
 package click.divichart.service;
 
+import click.divichart.bean.dto.DividendTotalForStockDto;
 import click.divichart.bean.dto.PieChartDto;
 import click.divichart.repository.DividendHistoryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 
@@ -27,6 +29,33 @@ public class PieChartService extends BasicChartService {
         LocalDate endDate = startDate.plusYears(1).minusDays(1);
         List<Object[]> dividendSummaryList = repository.getDividendTotalForStock(startDate, endDate);
         return createChartData(dividendSummaryList);
+    List<DividendTotalForStockDto> dataFormatting(List<Object[]> dividendSummaryList){
+
+        List<DividendTotalForStockDto> dividendTotalForStockDtoList = new ArrayList<>();
+        DividendTotalForStockDto other = new DividendTotalForStockDto(
+                "その他",
+                BigDecimal.ZERO
+        );
+
+        for (Object[] dividendSummary : dividendSummaryList) {
+            DividendTotalForStockDto dividendTotalForStockDto = new DividendTotalForStockDto(
+                    (String) dividendSummary[0],
+                    (BigDecimal) dividendSummary[1]
+            );
+            if(dividendTotalForStockDtoList.size() < 15){
+                dividendTotalForStockDtoList.add(dividendTotalForStockDto);
+            }else{
+                other.setAmountReceived(
+                        other.getAmountReceived().add(
+                                dividendTotalForStockDto.getAmountReceived()
+                        )
+                );
+            }
+        }
+        if(!other.getAmountReceived().equals(BigDecimal.ZERO)){
+            dividendTotalForStockDtoList.add(other);
+        }
+        return dividendTotalForStockDtoList;
     }
 
     /**

--- a/src/main/java/click/divichart/service/PieChartService.java
+++ b/src/main/java/click/divichart/service/PieChartService.java
@@ -28,7 +28,11 @@ public class PieChartService extends BasicChartService {
         LocalDate startDate = LocalDate.parse(year + "-01-01");
         LocalDate endDate = startDate.plusYears(1).minusDays(1);
         List<Object[]> dividendSummaryList = repository.getDividendTotalForStock(startDate, endDate);
-        return createChartData(dividendSummaryList);
+        List<DividendTotalForStockDto> dividendTotalForStockDtoList = dataFormatting(dividendSummaryList);
+
+        return createChartData(dividendTotalForStockDtoList);
+    }
+
     List<DividendTotalForStockDto> dataFormatting(List<Object[]> dividendSummaryList){
 
         List<DividendTotalForStockDto> dividendTotalForStockDtoList = new ArrayList<>();
@@ -61,16 +65,16 @@ public class PieChartService extends BasicChartService {
     /**
      * 配当情報からグラフ描画用のデータを生成する
      *
-     * @param dividendSummaryList 配当情報
+     * @param dividendTotalForStockDtoList 配当情報
      * @return グラフ描画用文字列配列
      */
-    PieChartDto createChartData(List<Object[]> dividendSummaryList) {
+    PieChartDto createChartData(List<DividendTotalForStockDto> dividendTotalForStockDtoList) {
         StringJoiner tickerSymbolData = new StringJoiner("\",\"", "\"", "\"");
         StringJoiner amountReceivedData = new StringJoiner(",");
 
-        for (Object[] dividendSummary : dividendSummaryList) {
-            String tickerSymbol = (String) dividendSummary[0];
-            BigDecimal amountReceived = (BigDecimal) dividendSummary[1];
+        for (DividendTotalForStockDto dividendTotalForStockDto : dividendTotalForStockDtoList) {
+            String tickerSymbol = dividendTotalForStockDto.getTickerSymbol();
+            BigDecimal amountReceived = dividendTotalForStockDto.getAmountReceived();
 
             tickerSymbolData.add(tickerSymbol);
             amountReceivedData.add(amountReceived.toString());

--- a/src/main/java/click/divichart/service/PieChartService.java
+++ b/src/main/java/click/divichart/service/PieChartService.java
@@ -35,6 +35,11 @@ public class PieChartService extends BasicChartService {
         return createChartData(dividendSummaryDtoList);
     }
 
+    /**
+     * 配当の集計情報を整形して、小さいデータはその他にまとめる
+     * @param dividendSummaryList 配当の集計情報
+     * @return 整形された配当の集計情報
+     */
     List<DividendSummaryDto> formatData(List<Object[]> dividendSummaryList) {
 
         List<DividendSummaryDto> dividendSummaryDtoList = new ArrayList<>();

--- a/src/test/java/click/divichart/service/PieChartServiceTest.java
+++ b/src/test/java/click/divichart/service/PieChartServiceTest.java
@@ -1,6 +1,6 @@
 package click.divichart.service;
 
-import click.divichart.bean.dto.DividendTotalForStockDto;
+import click.divichart.bean.dto.DividendSummaryDto;
 import click.divichart.bean.dto.PieChartDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,21 +22,21 @@ class PieChartServiceTest {
 
     @Test
     public void testCreateChartDataWithValidData() {
-        List<DividendTotalForStockDto> dividendTotalForStockDtoList = new ArrayList<>();
-        dividendTotalForStockDtoList.add(
-                new DividendTotalForStockDto(
+        List<DividendSummaryDto> dividendSummaryDtoList = new ArrayList<>();
+        dividendSummaryDtoList.add(
+                new DividendSummaryDto(
                         "AAPL",
                         BigDecimal.valueOf(100.01)
                 )
         );
-        dividendTotalForStockDtoList.add(
-                new DividendTotalForStockDto(
+        dividendSummaryDtoList.add(
+                new DividendSummaryDto(
                     "GOOG",
                     BigDecimal.valueOf(50.01)
                 )
         );
 
-        PieChartDto chartData = pieChartService.createChartData(dividendTotalForStockDtoList);
+        PieChartDto chartData = pieChartService.createChartData(dividendSummaryDtoList);
 
         assertNotNull(chartData);
 
@@ -47,7 +47,7 @@ class PieChartServiceTest {
 
     @Test
     public void testCreateChartDataWithEmptyList() {
-        List<DividendTotalForStockDto> emptyList = new ArrayList<>();
+        List<DividendSummaryDto> emptyList = new ArrayList<>();
 
         PieChartDto chartData = pieChartService.createChartData(emptyList);
 

--- a/src/test/java/click/divichart/service/PieChartServiceTest.java
+++ b/src/test/java/click/divichart/service/PieChartServiceTest.java
@@ -23,18 +23,8 @@ class PieChartServiceTest {
     @Test
     public void testCreateChartDataWithValidData() {
         List<DividendSummaryDto> dividendSummaryDtoList = new ArrayList<>();
-        dividendSummaryDtoList.add(
-                new DividendSummaryDto(
-                        "AAPL",
-                        BigDecimal.valueOf(100.01)
-                )
-        );
-        dividendSummaryDtoList.add(
-                new DividendSummaryDto(
-                    "GOOG",
-                    BigDecimal.valueOf(50.01)
-                )
-        );
+        dividendSummaryDtoList.add(new DividendSummaryDto("AAPL", BigDecimal.valueOf(100.01)));
+        dividendSummaryDtoList.add(new DividendSummaryDto("GOOG", BigDecimal.valueOf(50.01)));
 
         PieChartDto chartData = pieChartService.createChartData(dividendSummaryDtoList);
 

--- a/src/test/java/click/divichart/service/PieChartServiceTest.java
+++ b/src/test/java/click/divichart/service/PieChartServiceTest.java
@@ -1,5 +1,6 @@
 package click.divichart.service;
 
+import click.divichart.bean.dto.DividendTotalForStockDto;
 import click.divichart.bean.dto.PieChartDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,11 +22,21 @@ class PieChartServiceTest {
 
     @Test
     public void testCreateChartDataWithValidData() {
-        List<Object[]> dividendSummaryList = new ArrayList<>();
-        dividendSummaryList.add(new Object[]{"AAPL", BigDecimal.valueOf(100.01)});
-        dividendSummaryList.add(new Object[]{"GOOG", BigDecimal.valueOf(50.01)});
+        List<DividendTotalForStockDto> dividendTotalForStockDtoList = new ArrayList<>();
+        dividendTotalForStockDtoList.add(
+                new DividendTotalForStockDto(
+                        "AAPL",
+                        BigDecimal.valueOf(100.01)
+                )
+        );
+        dividendTotalForStockDtoList.add(
+                new DividendTotalForStockDto(
+                    "GOOG",
+                    BigDecimal.valueOf(50.01)
+                )
+        );
 
-        PieChartDto chartData = pieChartService.createChartData(dividendSummaryList);
+        PieChartDto chartData = pieChartService.createChartData(dividendTotalForStockDtoList);
 
         assertNotNull(chartData);
 
@@ -36,7 +47,7 @@ class PieChartServiceTest {
 
     @Test
     public void testCreateChartDataWithEmptyList() {
-        List<Object[]> emptyList = new ArrayList<>();
+        List<DividendTotalForStockDto> emptyList = new ArrayList<>();
 
         PieChartDto chartData = pieChartService.createChartData(emptyList);
 


### PR DESCRIPTION
配当割合グラフで表示する銘柄数を制限する

メソッドの責務が曖昧なところがあるが、それは後ほど全体的に見直す