### PR TITLE
凡例の表示を制限する

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>click.divichart</groupId>
 	<artifactId>divichart</artifactId>
-	<version>2.12.0</version>
+	<version>2.12.1</version>
 	<name>divichart</name>
 	<properties>
 		<java.version>17</java.version>

--- a/src/main/resources/templates/pieChart.html
+++ b/src/main/resources/templates/pieChart.html
@@ -42,6 +42,9 @@
                 } ]
             },
             options : {
+                animation: {
+                    animateScale: true
+                },
                 plugins: {
                     title: {
                         display: true,

--- a/src/main/resources/templates/pieChart.html
+++ b/src/main/resources/templates/pieChart.html
@@ -49,6 +49,9 @@
                     title: {
                         display: true,
                         text: '銘柄別  配当受取額割合'
+                    },
+                    legend: {
+                        maxHeight: 70
                     }
                 },
                 maintainAspectRatio: false,


### PR DESCRIPTION
- パーセント表示を追加したことによりグラフが縮小してしまったため修正する
  - 凡例の縦幅制限を入れている。
- （スコープ外だが）ついでにアニメーション追加もしている