### PR TITLE
グラフの下限値を設定する

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>click.divichart</groupId>
 	<artifactId>divichart</artifactId>
-	<version>2.15.0</version>
+	<version>2.16.0</version>
 	<name>divichart</name>
 
 	<properties>

--- a/src/main/resources/templates/cumulativeDividend.html
+++ b/src/main/resources/templates/cumulativeDividend.html
@@ -52,6 +52,7 @@
                 },
                 scales: {
                     y: {
+                        min: 0,
                         ticks: {
                             callback: function(value, index, ticks) {
                                 return value + 'ドル';

--- a/src/main/resources/templates/dividendIncreaseRate.html
+++ b/src/main/resources/templates/dividendIncreaseRate.html
@@ -41,6 +41,7 @@
                 },
                 scales: {
                     y: {
+                        min: -100,
                         ticks: {
                             callback: function(value, index, ticks) {
                                 return value + '%';


### PR DESCRIPTION
累計配当グラフにマイナスの数値は不要なためゼロを下限値とする

増配率グラフは最小値が-100%なので下限値を100にする