### PR TITLE
配当達成率グラフ画面のフォーム改善＆円換算情報追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>click.divichart</groupId>
 	<artifactId>divichart</artifactId>
-	<version>2.20.0</version>
+	<version>2.21.0</version>
 	<name>divichart</name>
 
 	<properties>

--- a/src/main/java/click/divichart/bean/dto/DividendAchievementRateDto.java
+++ b/src/main/java/click/divichart/bean/dto/DividendAchievementRateDto.java
@@ -14,10 +14,13 @@ public class DividendAchievementRateDto implements Serializable {
     private String labels;
     private String chartData;
     private String targetDividend;
+    private String targetDividendYen;
 
-    public DividendAchievementRateDto(String labels, String chartData, String targetDividend) {
+    public DividendAchievementRateDto(String labels, String chartData,
+                                      String targetDividend, String targetDividendYen) {
         this.labels = labels;
         this.chartData = chartData;
         this.targetDividend = targetDividend;
+        this.targetDividendYen = targetDividendYen;
     }
 }

--- a/src/main/java/click/divichart/controller/DividendAchievementRateController.java
+++ b/src/main/java/click/divichart/controller/DividendAchievementRateController.java
@@ -31,7 +31,7 @@ public class DividendAchievementRateController {
     @GetMapping
     public String index(Model model, DividendAchievementRateForm form) {
         log.debug("配当達成率表示");
-        String targetDividend = (form.getTargetDividend().isEmpty()) ? "100" : form.getTargetDividend();
+        String targetDividend = (form.getTargetDividend().isEmpty()) ? "135" : form.getTargetDividend();
 
         String labels = service.getLabels(5);
         String chartData = service.getChartData(5, targetDividend);

--- a/src/main/java/click/divichart/controller/DividendAchievementRateController.java
+++ b/src/main/java/click/divichart/controller/DividendAchievementRateController.java
@@ -36,10 +36,13 @@ public class DividendAchievementRateController {
         String labels = service.getLabels(5);
         String chartData = service.getChartData(5, targetDividend);
 
+        String targetDividendYen = service.exchange(targetDividend, "150");
+
         DividendAchievementRateDto dividendAchievementRateDto = new DividendAchievementRateDto(
                 labels,
                 chartData,
-                targetDividend
+                targetDividend,
+                targetDividendYen
         );
         model.addAttribute("dividendAchievementRateDto", dividendAchievementRateDto);
 

--- a/src/main/java/click/divichart/service/DividendAchievementRateService.java
+++ b/src/main/java/click/divichart/service/DividendAchievementRateService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.text.DecimalFormat;
 import java.time.LocalDate;
 import java.util.StringJoiner;
 
@@ -66,5 +67,18 @@ public class DividendAchievementRateService extends BasicChartService {
             labels.add(year);
         }
         return labels.toString();
+    }
+
+    /**
+     * 円に両替して返す
+     *
+     * @param targetDividend 目標配当
+     * @param rate           ドル円両替レート
+     * @return 円換算の目標配当 例）1,234,567
+     */
+    public String exchange(String targetDividend, String rate) {
+        BigDecimal targetDividendYen = new BigDecimal(targetDividend).multiply(new BigDecimal(rate));
+        DecimalFormat decimalFormat = new DecimalFormat("#,###");
+        return decimalFormat.format(targetDividendYen);
     }
 }

--- a/src/main/resources/templates/dividendAchievementRate.html
+++ b/src/main/resources/templates/dividendAchievementRate.html
@@ -13,21 +13,18 @@
     <h1>配当達成率グラフ</h1>
     <form th:action="@{/dividendAchievementRate}" method="get">
         <div class="mb-3">
-            <label for="targetDividend" class="form-label">月平均目標配当額（単位：USD）</label>
-            <select name="targetDividend" id="targetDividend" onchange="submit(this.form)" class="form-select">
-                <option th:value="10" th:text="10"
-                        th:selected="${'10' == dividendAchievementRateDto.getTargetDividend()}"></option>
-                <option th:value="100" th:text="100"
-                        th:selected="${'100' == dividendAchievementRateDto.getTargetDividend()}"></option>
-                <option th:value="200" th:text="200"
-                        th:selected="${'200' == dividendAchievementRateDto.getTargetDividend()}"></option>
-                <option th:value="500" th:text="500"
-                        th:selected="${'500' == dividendAchievementRateDto.getTargetDividend()}"></option>
-                <option th:value="700" th:text="700"
-                        th:selected="${'700' == dividendAchievementRateDto.getTargetDividend()}"></option>
-                <option th:value="1000" th:text="1000"
-                        th:selected="${'1000' == dividendAchievementRateDto.getTargetDividend()}"></option>
-            </select>
+            <label for="targetDividend" class="form-label">目標配当額（単位：USD/月）</label>
+            <input type="number" id="targetDividend" step="1" name="targetDividend" class="form-control"
+                   min="1" list="targetDividendList" onchange="submit(this.form)"
+                   th:value="${dividendAchievementRateDto.getTargetDividend()}" />
+            <datalist id="targetDividendList">
+                <option value="10"></option>
+                <option value="100"></option>
+                <option value="500"></option>
+                <option value="1000"></option>
+                <option value="3000"></option>
+                <option value="5000"></option>
+            </datalist>
         </div>
     </form>
     <div class="chart-container">

--- a/src/main/resources/templates/dividendAchievementRate.html
+++ b/src/main/resources/templates/dividendAchievementRate.html
@@ -27,6 +27,7 @@
             </datalist>
         </div>
     </form>
+    <p th:text="'換算：' + ${dividendAchievementRateDto.getTargetDividendYen()} + '円（150円/ドル）'"></p>
     <div class="chart-container">
         <canvas id="dividendAchievementRate"></canvas>
     </div>


### PR DESCRIPTION
- 表題通り
  - 配当目標額は自由に入力できるようにした
- ドル円レートは固定だがゆくゆくは設定できるようにしたい
- ついでに目標配当額の初期値を2万円に近づくよう変更した