### PR TITLE
Spring Boot 3.2系へ移行

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>click.divichart</groupId>
 	<artifactId>divichart</artifactId>
-	<version>3.2.0</version>
+	<version>3.3.0</version>
 	<name>divichart</name>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.9</version>
+		<version>3.2.3</version>
 	</parent>
 
 	<groupId>click.divichart</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
 		</dependency>
-		<!-- spring-boot-starter-thymeleafに含まれるが脆弱性回避のため個別にバージョンアップする -->
-		<dependency>
-			<groupId>org.yaml</groupId>
-			<artifactId>snakeyaml</artifactId>
-			<version>2.2</version>
-		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>


### PR DESCRIPTION
Spring Boot 3.1系 から 3.2系へ移行する
ローカルでビルドして、特に警告が出ていないことを確認済み。

また、依存関係の指定も見直した。