### PR TITLE
配当増加額グラフ追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>click.divichart</groupId>
     <artifactId>divichart</artifactId>
-    <version>3.4.0</version>
+    <version>3.5.0</version>
     <name>divichart</name>
 
     <properties>

--- a/src/main/java/click/divichart/bean/dto/DividendIncreaseDto.java
+++ b/src/main/java/click/divichart/bean/dto/DividendIncreaseDto.java
@@ -1,0 +1,23 @@
+package click.divichart.bean.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+/**
+ * 配当増加額グラフ画面用DTO
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class DividendIncreaseDto implements Serializable {
+    private String labels;
+    private String chartData;
+
+    public DividendIncreaseDto(String labels, String chartData) {
+        this.labels = labels;
+        this.chartData = chartData;
+    }
+}

--- a/src/main/java/click/divichart/controller/DividendIncreaseController.java
+++ b/src/main/java/click/divichart/controller/DividendIncreaseController.java
@@ -1,0 +1,54 @@
+package click.divichart.controller;
+
+import click.divichart.bean.dto.DividendIncreaseDto;
+import click.divichart.bean.dto.DividendIncreaseRateDto;
+import click.divichart.bean.form.MonthlyDividendForm;
+import click.divichart.service.DividendIncreaseService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * 配当増加率グラフ用コントローラ
+ */
+@Slf4j
+@Controller
+@RequestMapping("/dividendIncrease")
+public class DividendIncreaseController {
+
+    private final DividendIncreaseService service;
+
+    @Autowired
+    public DividendIncreaseController(DividendIncreaseService dividendIncreaseService) {
+        this.service = dividendIncreaseService;
+    }
+
+    /**
+     * グラフ表示用のデータを用意してViewへ渡す
+     */
+    @GetMapping
+    public String index(Model model, MonthlyDividendForm monthlyDividendForm,
+                        @AuthenticationPrincipal UserDetails user) {
+        log.debug("配当増加額表示");
+        String[] recentYears = service.getRecentYears(6).toArray(new String[0]);
+
+        String labels = service.getLabels(recentYears);
+        // 対象年取得
+        // ラベル取得
+        // 計算データ取得
+        // 両替
+        // 文字列化
+        // 情報セット
+        String chartData = service.getChartData(recentYears, user.getUsername());
+
+        DividendIncreaseDto dividendIncreaseDto = new DividendIncreaseDto(labels, chartData);
+        model.addAttribute("dividendIncreaseDto", dividendIncreaseDto);
+
+        return "dividendIncrease";
+    }
+}

--- a/src/main/java/click/divichart/service/DividendIncreaseService.java
+++ b/src/main/java/click/divichart/service/DividendIncreaseService.java
@@ -1,0 +1,69 @@
+package click.divichart.service;
+
+import click.divichart.repository.DividendHistoryRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.StringJoiner;
+
+/**
+ * 配当増加率グラフ用Service
+ */
+@Slf4j
+@Service
+public class DividendIncreaseService extends BasicChartService {
+
+    public DividendIncreaseService(DividendHistoryRepository dividendHistoryRepository) {
+        super(dividendHistoryRepository);
+    }
+
+    /**
+     * グラフ描画用に、指定年の配当増加率のデータを取得する
+     *
+     * @param recentYears 近年を表す文字列配列
+     * @param username    ユーザ名
+     * @return グラフ描画用文字列
+     */
+    public String getChartData(String[] recentYears, String username) {
+        // 今年の配当額マイナス昨年の配当額
+        BigDecimal[] differences = new BigDecimal[recentYears.length];
+
+        for (int i = 0; i < differences.length; i++) {
+            String targetYear = recentYears[differences.length - 1 - i];
+            LocalDate targetYearStartDate = LocalDate.parse(targetYear + "-01-01");
+            LocalDate targetYearEndDate = targetYearStartDate.plusYears(1).minusDays(1);
+            BigDecimal targetYearsDividend = repository.getDividendSum(
+                    targetYearStartDate,
+                    targetYearEndDate,
+                    username
+            );
+
+            LocalDate previousYearStartDate = targetYearStartDate.minusYears(1);
+            LocalDate previousYearEndDate = previousYearStartDate.plusYears(1).minusDays(1);
+            BigDecimal previousYearsDividend = repository.getDividendSum(
+                    previousYearStartDate,
+                    previousYearEndDate,
+                    username
+            );
+            differences[i] = targetYearsDividend.subtract(previousYearsDividend);
+        }
+        return createChartData(differences);
+    }
+
+    /**
+     * グラフのラベルを取得する
+     *
+     * @param recentYears 近年を表す文字列配列
+     * @return グラフ描画用ラベル文字列
+     */
+    public String getLabels(String[] recentYears) {
+        StringJoiner labels = new StringJoiner("年\",\"", "\"", "年\"");
+        for (int i = recentYears.length - 1; i >= 0; i--) {
+            String year = recentYears[i];
+            labels.add(year);
+        }
+        return labels.toString();
+    }
+}

--- a/src/main/resources/templates/dividendIncrease.html
+++ b/src/main/resources/templates/dividendIncrease.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="https://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>配当増加額グラフ</title>
+    <link th:href="@{/css/basicChart.css}" rel="styleSheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet"
+          integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
+</head>
+<body>
+    <header th:replace="~{header}"></header>
+    <h1>配当増加額グラフ</h1>
+    <p th:if="${#strings.isEmpty(dividendIncreaseDto.getChartData())}">データがありません</p>
+    <th:block th:if="${!#strings.isEmpty(dividendIncreaseDto.getChartData())}">
+    <div class="chart-container">
+        <canvas id="dividendIncrease"></canvas>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
+    <script>
+        const labels = [ [(${dividendIncreaseDto.getLabels()})] ];
+        const data = [ [[${dividendIncreaseDto.getChartData()}]] ];
+        const ctx = document.getElementById("dividendIncrease");
+        const chart = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: '増加額(ドル)',
+                    data: data,
+                    backgroundColor: "rgba(255, 0, 0, 0.5)"
+                }]
+            },
+            options: {
+                plugins: {
+                    title: {
+                        display: true,
+                        text: '前年比配当増加額'
+                    }
+                },
+                scales: {
+                    y: {
+                        min: -100,
+                        ticks: {
+                            callback: function(value, index, ticks) {
+                                return value + 'ドル';
+                            }
+                        }
+                    }
+                },
+                maintainAspectRatio: false
+            }
+        });
+    </script>
+    </th:block>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
+            integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"
+            crossorigin="anonymous">
+    </script>
+</body>
+</html>

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -42,6 +42,11 @@
                             </a>
                         </li>
                         <li class="nav-item">
+                            <a th:href="@{/dividendIncrease}" class="nav-link" style="color:white;">
+                                配当増加額グラフ
+                            </a>
+                        </li>
+                        <li class="nav-item">
                             <a th:href="@{/dividendAchievementRate}" class="nav-link" style="color:white;">
                                 配当達成率グラフ
                             </a>


### PR DESCRIPTION
配当増加額グラフ表示機能を追加した。
配当達成率グラフを参考に作成している。
ロジックは見直す余地が大いにあるが、一旦動くところまでは作成している。